### PR TITLE
Introduce C++ code template

### DIFF
--- a/templates/template.cpp
+++ b/templates/template.cpp
@@ -1,0 +1,32 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <queue>
+#include <stack>
+
+using namespace std;
+
+typedef long long LL; 
+typedef pair<int, int> pii; 
+typedef pair<LL, LL> pll; 
+typedef pair<string, string> pss; 
+typedef vector<int> vi; 
+typedef vector<vi> vvi; 
+typedef vector<pii> vii; 
+typedef vector<LL> vl; 
+typedef vector<vl> vvl;
+typedef queue<int> qi;
+typedef queue<char> qc;
+typedef stack<int> si;
+typedef stack<char> sc;
+
+int main(){
+	ios::sync_with_stdio(0); cin.tie(0); cout.tie(0);
+    
+	string line;
+	while(getline(cin, line)){
+		// perform operations on line, where line is a string representing a line of input
+	}
+
+	return 0;
+}

--- a/templates/template.java
+++ b/templates/template.java
@@ -1,0 +1,18 @@
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String args[]) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        while (st.hasMoreTokens()) { // iterates through all tokens in stdin
+            String token = st.nextToken(); // you can pass a string parameter as a delimiter to tokenize. ex. ","
+            // System.out.println(token);
+        }
+
+    }
+}


### PR DESCRIPTION
~Sorry for the word bomb

I think we shouldn't focus on our templates/boilerplates reading files through their own language specific implementations of file reading. 

Instead, I think we should do this on the shell level by instructing users to use a redirection such as `./main < input.txt`. We aren't doing anything more complicated than pushing a long input through stdin, which is exactly what redirection is awesome at. 

Also, if we want some extra work, this could potentially scale into a cute little CLI that pulls the input file from aoc, compiles it, executes it and tests it. However, that's just a reach. 
This C++ template just focuses on common short-forms, a hacky input speed optimization and quick way to read from stdin line by line. 

Question: If we should use redirection, where do we actually want to tell the user to do so?